### PR TITLE
Add msp_bidease bidder name

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -672,6 +672,7 @@ const (
 	BidderMspFbDelta      BidderName = "msp_fb_delta"
 	BidderMspMoloco       BidderName = "msp_moloco"
 	BidderMspMolocoNative BidderName = "msp_moloco_native"
+	BidderMspBidease      BidderName = "msp_bidease"
 	BidderMspTtdVideo     BidderName = "msp_ttd_video"
 	BidderMspVungleAlpha  BidderName = "msp_vungle_alpha"
 	BidderMspVungleBeta   BidderName = "msp_vungle_beta"

--- a/openrtb_ext/msp_bidders.go
+++ b/openrtb_ext/msp_bidders.go
@@ -13,6 +13,7 @@ func mspBidderNames() []BidderName {
 		BidderMspFbDelta,
 		BidderMspMoloco,
 		BidderMspMolocoNative,
+		BidderMspBidease,
 		BidderMspTtdVideo,
 		BidderMspVungleAlpha,
 		BidderMspVungleBeta,


### PR DESCRIPTION
## Summary
- Register the `msp_bidease` bidder name for the new Bidease DSP adapter.
- Adds the `BidderMspBidease` const in the MSP-extension block of `openrtb_ext/bidders.go` and the corresponding entry in `mspBidderNames()` (`openrtb_ext/msp_bidders.go`).

This follows the existing MSP bidder pattern (e.g. `msp_moloco`), keeping custom bidders isolated from the upstream `coreBidderNames` list. The adapter plugin, `static/bidder-params/msp_bidease.json`, `static/bidder-info/msp_bidease.yaml`, and config wiring live in the parent `msp` repo.

## Notes
- The adapter is shipped `disabled: true` with a placeholder endpoint/params pending real Bidease integration values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)