### PR TITLE
Add msp_google_native and msp_google_banner bidder names

### DIFF
--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -662,6 +662,8 @@ const (
 
 	// For MSP extension only
 	BidderMspGoogle       BidderName = "msp_google"
+	BidderMspGoogleNative BidderName = "msp_google_native"
+	BidderMspGoogleBanner BidderName = "msp_google_banner"
 	BidderMspNova         BidderName = "msp_nova"
 	BidderMspNovaAlpha    BidderName = "msp_nova_alpha"
 	BidderMspNovaBeta     BidderName = "msp_nova_beta"

--- a/openrtb_ext/msp_bidders.go
+++ b/openrtb_ext/msp_bidders.go
@@ -3,6 +3,8 @@ package openrtb_ext
 func mspBidderNames() []BidderName {
 	return []BidderName{
 		BidderMspGoogle,
+		BidderMspGoogleNative,
+		BidderMspGoogleBanner,
 		BidderMspNova,
 		BidderMspNovaAlpha,
 		BidderMspNovaBeta,


### PR DESCRIPTION
Register two Google sibling bidder names, `msp_google_native` and `msp_google_banner`, so MSP can call the Google adapter separately per format.

Follows the existing MSP bidder pattern established by #131 (`msp_bidease`):
- const in the MSP-extension block of `openrtb_ext/bidders.go`
- entry in `mspBidderNames()` in `openrtb_ext/msp_bidders.go`

Both names are served by the existing `msp_google.so`, the same way `msp_moloco_native` shares `msp_moloco.so`. The MSP-side PR supplies the native-only / banner-only `bidder-info`, the `bidder-params` schemas, and the per-env `adapters.*` config, and bumps the submodule pointer to this commit.

## Testing

- `go build ./openrtb_ext/...` and `go vet ./openrtb_ext/` clean
- `go test ./openrtb_ext/... ./config/...` pass
- `TestBidderInfoFiles` passes against the MSP static files. Verified that test has teeth: adding an unregistered bidder-info file makes it fail with `unknown bidder`, so a green run is real evidence both new names resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)