### PR TITLE
Stop preloading per-adapter Prometheus label values

### DIFF
--- a/metrics/prometheus/preload.go
+++ b/metrics/prometheus/preload.go
@@ -2,20 +2,25 @@ package prometheusmetrics
 
 import (
 	"github.com/prebid/prebid-server/v3/metrics"
-	"github.com/prebid/prebid-server/v3/openrtb_ext"
+	// "github.com/prebid/prebid-server/v3/openrtb_ext"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// MSP: the per-adapter preloads below are commented out rather than deleted, so a
+// rebase onto upstream keeps them visible and they can be switched back on in one
+// edit. They created a full series set for all ~340 bidders compiled into the
+// binary -- 9,180 series a pod, 97% of this registry -- for bidders that never see
+// a request. Adapter series are now created lazily on first use.
 func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[string][]string) {
 	var (
-		adapterErrorValues        = enumAsString(metrics.AdapterErrors())
-		adapterValues             = enumAsLowerCaseString(openrtb_ext.CoreBidderNames())
-		bidTypeValues             = []string{markupDeliveryAdm, markupDeliveryNurl}
-		boolValues                = boolValuesAsString()
-		cacheResultValues         = enumAsString(metrics.CacheResults())
-		connectionErrorValues     = []string{connectionAcceptError, connectionCloseError}
-		cookieSyncStatusValues    = enumAsString(metrics.CookieSyncStatuses())
-		cookieValues              = enumAsString(metrics.CookieTypes())
+		// adapterErrorValues        = enumAsString(metrics.AdapterErrors())
+		// adapterValues             = enumAsLowerCaseString(openrtb_ext.CoreBidderNames())
+		// bidTypeValues             = []string{markupDeliveryAdm, markupDeliveryNurl}
+		boolValues             = boolValuesAsString()
+		cacheResultValues      = enumAsString(metrics.CacheResults())
+		connectionErrorValues  = []string{connectionAcceptError, connectionCloseError}
+		cookieSyncStatusValues = enumAsString(metrics.CookieSyncStatuses())
+		// cookieValues              = enumAsString(metrics.CookieTypes())
 		overheadTypes             = enumAsString(metrics.OverheadTypes())
 		requestStatusValues       = enumAsString(metrics.RequestStatuses())
 		requestTypeValues         = enumAsString(metrics.RequestTypes())
@@ -124,81 +129,81 @@ func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[st
 		cacheResultLabel: cacheResultValues,
 	})
 
-	preloadLabelValuesForCounter(m.adapterBids, map[string][]string{
-		adapterLabel:        adapterValues,
-		markupDeliveryLabel: bidTypeValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterBids, map[string][]string{
+	// 		adapterLabel:        adapterValues,
+	// 		markupDeliveryLabel: bidTypeValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterErrors, map[string][]string{
-		adapterLabel:      adapterValues,
-		adapterErrorLabel: adapterErrorValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterErrors, map[string][]string{
+	// 		adapterLabel:      adapterValues,
+	// 		adapterErrorLabel: adapterErrorValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterPanics, map[string][]string{
-		adapterLabel: adapterValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterPanics, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterBidResponseSecureMarkupError, map[string][]string{
-		adapterLabel: adapterValues,
-		successLabel: boolValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterBidResponseSecureMarkupError, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 		successLabel: boolValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterBidResponseSecureMarkupWarn, map[string][]string{
-		adapterLabel: adapterValues,
-		successLabel: boolValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterBidResponseSecureMarkupWarn, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 		successLabel: boolValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterBidResponseValidationSizeError, map[string][]string{
-		adapterLabel: adapterValues,
-		successLabel: boolValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterBidResponseValidationSizeError, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 		successLabel: boolValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterBidResponseValidationSizeWarn, map[string][]string{
-		adapterLabel: adapterValues,
-		successLabel: boolValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterBidResponseValidationSizeWarn, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 		successLabel: boolValues,
+	// 	})
 
-	preloadLabelValuesForHistogram(m.adapterPrices, map[string][]string{
-		adapterLabel: adapterValues,
-	})
+	// 	preloadLabelValuesForHistogram(m.adapterPrices, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 	})
 
-	preloadLabelValuesForCounter(m.adapterRequests, map[string][]string{
-		adapterLabel: adapterValues,
-		cookieLabel:  cookieValues,
-		hasBidsLabel: boolValues,
-	})
+	// 	preloadLabelValuesForCounter(m.adapterRequests, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 		cookieLabel:  cookieValues,
+	// 		hasBidsLabel: boolValues,
+	// 	})
 
 	preloadLabelValuesForCounter(m.adsCertRequests, map[string][]string{
 		successLabel: boolValues,
 	})
 
-	if !m.metricsDisabled.AdapterConnectionMetrics {
-		preloadLabelValuesForCounter(m.adapterCreatedConnections, map[string][]string{
-			adapterLabel: adapterValues,
-		})
+	// if !m.metricsDisabled.AdapterConnectionMetrics {
+	// 		preloadLabelValuesForCounter(m.adapterCreatedConnections, map[string][]string{
+	// 			adapterLabel: adapterValues,
+	// 		})
 
-		preloadLabelValuesForCounter(m.adapterReusedConnections, map[string][]string{
-			adapterLabel: adapterValues,
-		})
+	// 		preloadLabelValuesForCounter(m.adapterReusedConnections, map[string][]string{
+	// 			adapterLabel: adapterValues,
+	// 		})
 
-		preloadLabelValuesForHistogram(m.adapterConnectionWaitTime, map[string][]string{
-			adapterLabel: adapterValues,
-		})
+	// 		preloadLabelValuesForHistogram(m.adapterConnectionWaitTime, map[string][]string{
+	// 			adapterLabel: adapterValues,
+	// 		})
 
-		if !m.metricsDisabled.AdapterConnectionDialMetrics {
-			preloadLabelValuesForCounter(m.adapterConnectionDialErrors, map[string][]string{
-				adapterLabel: adapterValues,
-			})
+	// if !m.metricsDisabled.AdapterConnectionDialMetrics {
+	// 			preloadLabelValuesForCounter(m.adapterConnectionDialErrors, map[string][]string{
+	// 				adapterLabel: adapterValues,
+	// 			})
 
-			preloadLabelValuesForHistogram(m.adapterConnectionDialTime, map[string][]string{
-				adapterLabel: adapterValues,
-			})
-		}
-	}
+	// 			preloadLabelValuesForHistogram(m.adapterConnectionDialTime, map[string][]string{
+	// 				adapterLabel: adapterValues,
+	// 			})
+	// }
+	// }
 
-	preloadLabelValuesForHistogram(m.adapterRequestsTimer, map[string][]string{
-		adapterLabel: adapterValues,
-	})
+	// 	preloadLabelValuesForHistogram(m.adapterRequestsTimer, map[string][]string{
+	// 		adapterLabel: adapterValues,
+	// 	})
 
 	preloadLabelValuesForHistogram(m.overheadTimer, map[string][]string{
 		overheadTypeLabel: overheadTypes,
@@ -239,17 +244,17 @@ func preloadLabelValues(m *Metrics, syncerKeys []string, moduleStageNames map[st
 		versionLabel: tcfVersionValues,
 	})
 
-	if !m.metricsDisabled.AdapterBuyerUIDScrubbed {
-		preloadLabelValuesForCounter(m.adapterScrubbedBuyerUIDs, map[string][]string{
-			adapterLabel: adapterValues,
-		})
-	}
+	// if !m.metricsDisabled.AdapterBuyerUIDScrubbed {
+	// 		preloadLabelValuesForCounter(m.adapterScrubbedBuyerUIDs, map[string][]string{
+	// 			adapterLabel: adapterValues,
+	// 		})
+	// }
 
-	if !m.metricsDisabled.AdapterGDPRRequestBlocked {
-		preloadLabelValuesForCounter(m.adapterGDPRBlockedRequests, map[string][]string{
-			adapterLabel: adapterValues,
-		})
-	}
+	// if !m.metricsDisabled.AdapterGDPRRequestBlocked {
+	// 		preloadLabelValuesForCounter(m.adapterGDPRBlockedRequests, map[string][]string{
+	// 			adapterLabel: adapterValues,
+	// 		})
+	// }
 
 	for module, stageValues := range moduleStageNames {
 		preloadLabelValuesForHistogram(m.moduleDuration[module], map[string][]string{

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -53,19 +53,18 @@ func TestMetricCountGatekeeping(t *testing.T) {
 		}
 	}
 
-	// Calculate Per-Adapter Cardinality
-	adapterCount := len(openrtb_ext.CoreBidderNames())
-	perAdapterCardinalityCount := adapterCardinalityCount / adapterCount
 	// Verify General Cardinality
 	// - This assertion provides a warning for newly added high-cardinality non-adapter specific metrics. The hardcoded limit
 	//   is an arbitrary soft ceiling. Thought should be given as to the value of the new metrics if you find yourself
 	//   needing to increase this number.
 	assert.True(t, generalCardinalityCount <= 500, "General Cardinality")
 
-	// Verify Per-Adapter Cardinality
-	// - This assertion provides a warning for newly added adapter metrics. Threre are 40+ adapters which makes the
-	//   cost of new per-adapter metrics rather expensive. Thought should be given when adding new per-adapter metrics.
-	assert.True(t, perAdapterCardinalityCount <= 33, "Per-Adapter Cardinality count equals %d \n", perAdapterCardinalityCount)
+	// MSP: per-adapter preloading is off (see preload.go), so nothing gathered here should
+	// carry an adapter label. Upstream asserted a ceiling on per-adapter cardinality, which
+	// would now pass on a count of zero and guard nothing. This asserts the invariant we
+	// actually want: re-enabling a preload block fails the test, because it puts ~340
+	// bidders x that metric back onto every pod.
+	assert.Zero(t, adapterCardinalityCount, "Adapter metrics should not be preloaded")
 }
 
 func TestConnectionMetrics(t *testing.T) {


### PR DESCRIPTION
## Why

`preloadLabelValues` walks `CoreBidderNames()` and calls `.With()` on every adapter metric, so all ~340 bidders compiled into the binary (263 in the core list + 77 aliases registered at config load) get a full series set created at zero and exported forever — whether or not they ever see a request.

Measured against a real `msp-prod` registry:

```
before:  per-pod series=9429  adapter-labeled=9180  (97.4%)
after:   per-pod series=249   adapter-labeled=0
```

Times 16–140 replicas depending on deployment. Only **39** bidders are referenced anywhere in our stored requests. SRE is currently carrying **792,360 series** and this is very nearly all of it.

Worth noting: `adapters.<x>.disabled: true` does **not** help. Preload never consults `BidderInfos`, so enabled and disabled bidders are preloaded alike.

## Commented, not deleted

So a rebase onto upstream keeps the blocks visible and one edit puts them back. Along with them go the four locals that only fed adapter preloads (`adapterValues`, `adapterErrorValues`, `bidTypeValues`, `cookieValues`), the `openrtb_ext` import behind `CoreBidderNames()`, and the three `metricsDisabled.Adapter*` wrappers that would otherwise be no-op conditionals around nothing.

## What this gives up

The zero baseline — and the baseline was allocated backwards. It existed for the ~340 upstream bidders nobody calls, and was **missing for every `msp_*` bidder**, because those were never in `CoreBidderNames()`. So we're dropping a property we only had where it was worthless.

After this, a bidder that is configured but never called reads as *no data* rather than `0`. Bidders that actually serve get their series lazily on first use, exactly as ours always did. `sum(rate(...))` is unaffected. Worth a skim of the adapter dashboards for panels that assume a series exists.

## Test

`TestMetricCountGatekeeping` divided adapter cardinality by the bidder count, so with nothing preloaded it would pass on a count of zero and guard nothing. Replaced with an assertion that nothing per-adapter is preloaded, which fails loudly if a block is switched back on. **Verified it bites**: temporarily re-enabling the `adapter_panics` preload fails with "Adapter metrics should not be preloaded".

`go build ./...` and `go vet ./...` clean; `./validate.sh --nofmt` passes except a pre-existing local `./exchange` failure (`msp_nova: builder not registered` — plugin builders aren't registered under plain `go test`; fails identically with this change stashed).

## Follow-up

The parent `msp` repo needs a submodule pointer bump to pick this up, then a canary → promote deploy. This also makes ParticleMedia/msp#3077 (a scrape-time relabel doing the same job at ingest) redundant — closing that in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
